### PR TITLE
Use Retry.DEFAULT_ALLOWED_METHODS

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -164,7 +164,7 @@ class OpenIdBaseClient(OpenIdProxyClient):
         # Also hold on to retry logic.
         # http://www.coglib.com/~icordasc/blog/2014/12/retries-in-requests.html
         server_errors = [500, 501, 502, 503, 504, 506, 507, 508, 509, 599]
-        method_whitelist = Retry.DEFAULT_METHOD_WHITELIST.union(set(['POST']))
+        method_whitelist = Retry.DEFAULT_ALLOWED_METHODS.union(set(['POST']))
         if retries is not None:
             prefixes = ['http://', 'https://']
             for prefix in prefixes:


### PR DESCRIPTION
urllib3 1.26.0[1] deprecated Retry.DEFAULT_METHOD_WHITELIST, and now requires the use of Retry.DEFAULT_ALLOWED_METHODS.

[1]: https://urllib3.readthedocs.io/en/stable/changelog.html#id33