### PR TITLE
Fix CSRF token encoding and improve debug logging

### DIFF
--- a/fedora/client/proxyclient.py
+++ b/fedora/client/proxyclient.py
@@ -336,7 +336,7 @@ class ProxyClient(object):
         complete_params = req_params or {}
         if session_id:
             # Add the csrf protection token
-            token = sha1(str(session_id))
+            token = sha1(str(session_id).encode('utf-8'))
             complete_params.update({'_csrf_token': token.hexdigest()})
 
         auth = None
@@ -358,7 +358,7 @@ class ProxyClient(object):
         self.log.debug('Creating request %(url)s' %
                        {'url': str(url)})
         self.log.debug('Headers: %(header)s' %
-                       {'header': str(headers, nonstring='simplerepr')})
+                       {'header': str(headers)})
         if self.debug and complete_params:
             debug_data = copy.deepcopy(complete_params)
 


### PR DESCRIPTION
Needed for python-3.14

  File "/usr/lib/python3.14/site-packages/fedora/client/proxyclient.py", line 339, in send_request
    token = sha1(str(session_id))
TypeError: Strings must be encoded before hashing


  File "/usr/lib/python3.14/site-packages/fedora/client/proxyclient.py", line 361, in send_request
    {'header': str(headers, nonstring='simplerepr')})
               ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^