### PR TITLE
group_members: Fix docstring syntax error

### DIFF
--- a/fedora/client/fas2.py
+++ b/fedora/client/fas2.py
@@ -389,12 +389,11 @@ class AccountSystem(BaseClient):
 
         This method returns a list of people who are in the requested group.
         The people are all approved in the group.  Unapproved people are not
-        shown.  The format of data is::
-
-            \[{'username': 'person1', 'role_type': 'user'},
-            \{'username': 'person2', 'role_type': 'sponsor'}]
-
-        role_type can be one of 'user', 'sponsor', or 'administrator'.
+        shown.
+        :rtype: :obj:`list`
+        :returns: A list of :obj:`munch.Munch` objects, each with members
+            'username' and 'role_type'.
+            'role_type' can be one of 'user', 'sponsor', or 'administrator'.
 
         .. versionadded:: 0.3.2
         .. versionchanged:: 0.3.21


### PR DESCRIPTION
The docstring for `fas2.AccountSystem.group_members`  was triggering SyntaxWarnings in Python 3.14 due to invalid escape sequences.

Since it was out-of-date anyway, update it with current info and no dodgy backslash escapes.

Without this fix (wrapped for readability):

```console
$ rfpkg clone free/videomorph
/usr/lib/python3.14/site-packages/fedora/client/fas2.py:394: 
 SyntaxWarning: "\[" is an invalid escape sequence. 
 Such sequences will not work in the future. 
 Did you mean "\\["? A raw string is also an option.
  \[{'username': 'person1', 'role_type': 'user'},
```